### PR TITLE
lists method deprecated replaced with pluck

### DIFF
--- a/src/Phoenix/EloquentMeta/MetaTrait.php
+++ b/src/Phoenix/EloquentMeta/MetaTrait.php
@@ -11,7 +11,7 @@ trait MetaTrait
      */
     public function getAllMeta()
     {
-        return new Collection($this->meta->lists('value', 'key'));
+        return new Collection($this->meta->pluck('value', 'key'));
     }
 
     /**


### PR DESCRIPTION
lists method deprecated in laravel 5.3 replaced with pluck